### PR TITLE
Add Dockerfile and .dockerignore for containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+scripts/
+*.md
+pyinstaller.spec
+.dockerignore
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "gateway"]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
 Closes #56                                                                                                     
                                                                                                                 
  ## Changes                                                                                                     
  - Added Dockerfile based on python:3.11-slim                                                                   
  - Added .dockerignore to exclude unnecessary files from the image
                                                                                                                 
  ## Testing
  Built and ran the image locally with:                                                                          
  docker build -t nvidia-ai-gateway .                       
  docker run nvidia-ai-gateway 